### PR TITLE
chore: bump version to 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "responsive-scale-mixins",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Powerful SCSS mixins for responsive design with Figma proportions. Automatically scales typography, spacing, and dimensions across desktop, tablet, and mobile breakpoints.",
   "main": "index.scss",
   "style": "index.scss",


### PR DESCRIPTION
Updated package.json version from 1.1.0 to 1.1.1, likely for a patch release addressing minor fixes or improvements in the responsive-scale-mixins library.